### PR TITLE
Update Job Openings from Newton -> Greenhouse

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.3.0)
+    listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -249,7 +249,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -146,3 +146,14 @@ To contribute blog content, you need to setup an account and be associated as an
 * Include at least one image that can make a good "cover" image
 * Include descriptive alt text for all images
 * Make good use of headings and other techniques to make content readable and scannable
+
+## Job Board Integration (Greenhouse)
+
+Our job board is integrated in two places:
+
+- **Lob List on Main JOIN US Page:** `_content/join/02_openings.md` pulls in the listing of current openings.
+- **Openings Detail View:** `content/join/openings.md` is the page that houses the job detail, and is the path that greenhouse points to.
+
+### Custom CSS for Greenhouse
+
+The file `css/greenhouse.css` contains custom CSS additions for the contents of the greenhouse iframe. In the greenhouse configuration, you can either point to a URL for the file, or upload directly. So far we've uploaded directly, but just verify on the greenhouse config if it is not working as desired.

--- a/_content/join/02_openings.md
+++ b/_content/join/02_openings.md
@@ -5,4 +5,8 @@ style: highlight
 
 
 
-<script id="gnewtonjs" type="text/javascript" src="//newton.newtonsoftware.com/career/iframe.action?clientId=8a7882605aa73085015ab02149312a3d"></script>
+<!-- <script id="gnewtonjs" type="text/javascript" src="//newton.newtonsoftware.com/career/iframe.action?clientId=8a7882605aa73085015ab02149312a3d"></script> -->
+
+<div id="grnhse_app"></div>
+
+<script src="https://boards.greenhouse.io/embed/job_board/js?for=pluribusdigital"></script>

--- a/content/join/openings.md
+++ b/content/join/openings.md
@@ -2,6 +2,7 @@
 layout: interior
 title: Openings
 include_join_us: false
+permalink: /join/openings
 ---
 
 <div id="grnhse_app"></div>

--- a/css/greenhouse.css
+++ b/css/greenhouse.css
@@ -1,4 +1,4 @@
 div#main div#wrapper div#logo {display: none;}
 h1 {display: none;}
 h2#board_title {display: none;}
-body {font-size: 1.25rem !important;}
+body {font-size: 20px !important;}

--- a/css/greenhouse.css
+++ b/css/greenhouse.css
@@ -1,0 +1,4 @@
+div#main div#wrapper div#logo {display: none;}
+h1 {display: none;}
+h2#board_title {display: none;}
+body {font-size: 1.25rem !important;}

--- a/css/greenhouse.css
+++ b/css/greenhouse.css
@@ -2,3 +2,4 @@ div#main div#wrapper div#logo {display: none;}
 h1 {display: none;}
 h2#board_title {display: none;}
 body {font-size: 20px !important;}
+div#main {padding: 0px;}


### PR DESCRIPTION
Update integration scripts to embed Greenhouse content (via script/iframe) instead of Newton.